### PR TITLE
Support configurable OpenCity input windows

### DIFF
--- a/model/OpenCity/OpenCity.py
+++ b/model/OpenCity/OpenCity.py
@@ -317,7 +317,12 @@ class OpenCity(nn.Module):
         ])
 
         self.flatten = nn.Flatten(start_dim=-2)
-        self.linear = nn.Linear(24*self.skip_dim, self.output_window)
+        num_patches = (
+            (self.input_window - self.patch_embedding_flow.patch_len)
+            // self.patch_embedding_flow.stride
+            + 1
+        )
+        self.linear = nn.Linear(num_patches * self.skip_dim, self.output_window)
 
 
     def forward(self, input, lbls, select_dataset):


### PR DESCRIPTION
## What changed

- derive the prediction head input width from the configured `input_window`, patch length, and stride
- keep the default 288-step configuration at 24 patches, preserving its existing weight shape
- allow a 96-step configuration to construct an 8-patch prediction head instead of multiplying an 8-patch tensor by a hard-coded 24-patch layer

## Why

The patch embedding already adapts its number of patches to `input_window`, but the final linear layer was fixed at `24 * skip_dim`. Changing `input_window` to 96 therefore produced 8 patches and failed with a matrix dimension mismatch.

Fixes #16.

## Validation

- parsed `model/OpenCity/OpenCity.py` successfully under the local Python environment
- ran real PyTorch forwards with lightweight `enc_depth=0` fixtures for both 288-step/24-patch and 96-step/8-patch inputs
- verified both configurations produced finite outputs with shape `(2, 4, 2, 1)`
- verified the default 288-step layer still has `24 * skip_dim` input features

Full dataset training was not run.
